### PR TITLE
fix: 模型选择器 tooltip 切换模型后不更新

### DIFF
--- a/src/components/MultiModelSelector.svelte
+++ b/src/components/MultiModelSelector.svelte
@@ -482,20 +482,18 @@
         return getModelName(currentProvider, currentModelId);
     }
 
-    // 根据容器宽度自适应显示模型名称（单选模式）
-    $: displayModelName = (() => {
-        // 明确依赖这些变量以确保响应式更新
-        const _provider = currentProvider;
-        const _modelId = currentModelId;
-        const _width = containerWidth;
+    // 完整模型名称（响应式）— 直接引用 currentProvider/currentModelId 确保 Svelte 追踪依赖
+    $: fullModelName = currentProvider && currentModelId
+        ? getModelName(currentProvider, currentModelId)
+        : t('models.selectPlaceholder');
 
-        const name = getCurrentModelName();
-        if (!name || name === t('models.selectPlaceholder')) return name;
-        // 如果容器宽度小于 200px，只显示模型名的前10个字符
-        if (_width > 0 && _width < 200) {
-            return name.length > 10 ? name.substring(0, 10) + '...' : name;
+    // 根据容器宽度自适应截断的模型名称（单选模式）
+    $: displayModelName = (() => {
+        if (!fullModelName || fullModelName === t('models.selectPlaceholder')) return fullModelName;
+        if (containerWidth > 0 && containerWidth < 200 && fullModelName.length > 10) {
+            return fullModelName.substring(0, 10) + '...';
         }
-        return name;
+        return fullModelName;
     })();
 
     function closeOnOutsideClick(event: MouseEvent) {
@@ -621,7 +619,7 @@
         class="multi-model-selector__button b3-button b3-button--text"
         class:multi-model-selector__button--active={enableMultiModel}
         on:click|stopPropagation={() => (isOpen = !isOpen)}
-        title={enableMultiModel ? t('multiModel.title') : getCurrentModelName()}
+        title={enableMultiModel ? t('multiModel.title') : fullModelName}
     >
         <svg class="b3-button__icon">
             <use xlink:href="#iconLayout"></use>


### PR DESCRIPTION
## 问题

在侧边栏工具栏切换模型后，按钮的 tooltip 仍然显示旧模型名称。

**原因**：按钮 `title` 属性使用 `getCurrentModelName()` 函数调用，Svelte 编译器无法透过函数调用追踪到 `currentProvider` / `currentModelId` 的依赖变化，因此切换模型后 tooltip 不会重新计算。

而按钮文本 `displayModelName` 不受影响，是因为它的 `$:` 声明中显式引用了这些变量。

## 修复

- 提取 `fullModelName` 响应式变量，直接引用 `currentProvider` / `currentModelId`，使 Svelte 能正确追踪依赖
- `displayModelName` 改为从 `fullModelName` 派生，消除重复的依赖声明
- 按钮 `title` 改用 `fullModelName`