### PR TITLE
fix: Gemini 图片生成直连 Google 时使用 ?key= 参数认证

### DIFF
--- a/src/ai-chat.ts
+++ b/src/ai-chat.ts
@@ -1756,8 +1756,11 @@ export async function chat(
         // 强制使用 Gemini 原生图片生成接口（支持多轮）
         let customModalities = ["TEXT", "IMAGE"]; // 默认图文并茂
 
-        const imageUrl = `${baseUrlForGemini}/v1beta/models/${options.model}:generateContent`;
-        
+        // 直连 Google 用 ?key= 参数（与 chatGeminiFormat 保持一致）；中转站用 Bearer header
+        const useKeyParam = !customApiUrl;
+        const imageUrl = `${baseUrlForGemini}/v1beta/models/${options.model}:generateContent`
+            + (useKeyParam ? `?key=${options.apiKey}` : '');
+
         let contents = [];
         try {
             contents = await prepareGeminiContents(options.messages, true);
@@ -1777,7 +1780,7 @@ export async function chat(
 
         const headers: Record<string, string> = {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${options.apiKey}`
+            ...(useKeyParam ? {} : { 'Authorization': `Bearer ${options.apiKey}` }),
         };
 
         try {


### PR DESCRIPTION
## Summary

- 直连 Google API 时，Gemini 图片生成接口使用 `Authorization: Bearer` 携带 API Key 会返回 `401 ACCESS_TOKEN_TYPE_UNSUPPORTED`（Bearer 仅支持 OAuth Token，不支持 API Key）
- 改为与 `chatGeminiFormat`（流式对话）一致的 `?key=` URL 参数方式
- 中转站（自定义 API URL）仍保留 `Bearer` header，兼容第三方代理服务

## Details

Google Gemini API 支持两种认证方式：
1. `?key=API_KEY`（URL 参数）— 适用于 API Key
2. `Authorization: Bearer TOKEN`（HTTP header）— 仅适用于 OAuth 2.0 Token

当前代码在图片生成分支中使用了 `Authorization: Bearer ${apiKey}`，对于 Google AI Studio 的 API Key 会认证失败。本 PR 通过 `customApiUrl` 判断是否为直连 Google：
- **直连**（`customApiUrl` 为空）：使用 `?key=` 参数，与已有的 `chatGeminiFormat` 保持一致
- **中转站**（`customApiUrl` 非空）：保留 `Bearer` header，兼容第三方代理

Ref: #129

## Test plan

- [x] 直连 Google API（无自定义 URL）使用 `gemini-2.5-flash-preview-image-generation` 等图片模型，确认请求成功
- [ ] 使用中转站（自定义 API URL）确认 Bearer 认证仍正常工作