### PR TITLE
feat: 完善思源 forwardProxy 代理支持

### DIFF
--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -530,7 +530,9 @@
             "chatUrlPlaceholderGemini": "Leave empty to use default, e.g.: https://generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent",
             "chatUrlPlaceholderAnthropic": "Leave empty to use default, e.g.: https://api.anthropic.com/v1/messages",
             "hint": "Advanced settings allow complete customization of API endpoints, suitable for special API proxies or non-standard implementations"
-        }
+        },
+        "useForwardProxy": "Use Siyuan Proxy",
+        "useForwardProxyHint": "Forward requests through Siyuan Note backend to bypass browser CORS restrictions. (Non-streaming output)"
     },
     "common": {
         "untitled": "Untitled Document",

--- a/i18n/zh_CN.json
+++ b/i18n/zh_CN.json
@@ -531,7 +531,9 @@
             "chatUrlPlaceholderGemini": "留空使用默认接口，例如: https://generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent",
             "chatUrlPlaceholderAnthropic": "留空使用默认接口，例如: https://api.anthropic.com/v1/messages",
             "hint": "高级设置允许完全自定义 API 端点，适用于特殊的 API 代理或非标准实现"
-        }
+        },
+        "useForwardProxy": "使用思源代理",
+        "useForwardProxyHint": "通过思源笔记后端转发请求，可绕过浏览器的 CORS 跨域限制。（非流式输出）"
     },
     "common": {
         "untitled": "未命名文档",

--- a/src/ai-chat.ts
+++ b/src/ai-chat.ts
@@ -4,6 +4,7 @@
  * 支持图片生成功能
  */
 
+import { forwardProxyFetch } from './api';
 export interface ToolCall {
     id: string;
     type: 'function';
@@ -139,6 +140,7 @@ export interface ChatOptions {
     customBody?: any; // 自定义请求体参数
     enableImageGeneration?: boolean; // 是否启用图片生成
     onImageGenerated?: (images: GeneratedImageData[]) => void; // 图片生成回调
+    useForwardProxy?: boolean; // 是否使用思源笔记后端代理绕过 CORS
 }
 
 export interface ModelInfo {
@@ -548,7 +550,9 @@ export async function fetchModels(
     provider: string,
     apiKey: string,
     customApiUrl?: string,
-    advancedConfig?: AdvancedProviderConfig
+    advancedConfig?: AdvancedProviderConfig,
+    useForwardProxy?: boolean,
+    chatInterface?: ChatInterfaceType // 根据不同的平台接口，走不同的 API Key 认证方式
 ): Promise<ModelInfo[]> {
     const isBuiltIn = ['gemini', 'deepseek', 'openai', 'moonshot', 'volcano', 'Achuan', 'minimax'].includes(provider);
     const config = isBuiltIn ? PROVIDER_CONFIGS[provider as AIProvider] : PROVIDER_CONFIGS.custom;
@@ -580,16 +584,34 @@ export async function fetchModels(
         };
 
         // 处理不同平台的认证方式
-        if (provider === 'gemini') {
+        if (chatInterface === 'anthropic') {
+        // Anthropic 使用 x-api-key 和 anthropic-version 作为 header，比 Authorization 方式更加规范，且可以适配 Kimi Code API
+            headers['x-api-key'] = apiKey; 
+            headers['anthropic-version'] = '2023-06-01';
+        } else if (provider === 'gemini' || chatInterface === 'gemini') {
             headers[config.apiKeyHeader] = apiKey;
         } else {
-            headers[config.apiKeyHeader] = `Bearer ${apiKey}`;
+            headers['Authorization'] = `Bearer ${apiKey}`; // OpenAI 接口
         }
 
-        const response = await fetch(url, {
-            method: 'GET',
-            headers
-        });
+        let response: Response;
+        if (useForwardProxy) {
+            console.log('[fetchModels] forwardProxy headers:', headers, 'chatInterface:', chatInterface);
+            const result = await forwardProxyFetch(url, {
+                method: 'GET',
+                headers,
+                timeout: 30000
+            });
+            response = new Response(await result.text(), {
+                status: result.status,
+                headers: result.headers
+            });
+        } else {
+            response = await fetch(url, {
+                method: 'GET',
+                headers
+            });
+        }
 
         if (!response.ok) {
             if (shouldUseMiniMaxFallback) {
@@ -907,6 +929,78 @@ async function chatOpenAIFormat(
         'Authorization': `Bearer ${apiKey}`
     };
 
+    // ===== forwardProxy 模式：强制非流式，通过思源后端绕过 CORS =====
+    if (options.useForwardProxy) {
+        requestBody.stream = false;
+        delete requestBody.stream_options;
+
+        try {
+            const result = await forwardProxyFetch(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(requestBody),
+                timeout: 120000
+            });
+
+            if (!result.ok) {
+                let errorMessage = `API request failed: ${result.status}`;
+                try {
+                    const errorData = await result.json();
+                    const detailMsg = errorData.error?.message || errorData.message || errorData.error || JSON.stringify(errorData);
+                    errorMessage += `\n\n${detailMsg}`;
+                } catch (e) {
+                    try {
+                        const errorText = await result.text();
+                        if (errorText) errorMessage += `\n\n${errorText}`;
+                    } catch (_) {}
+                }
+                throw new Error(errorMessage);
+            }
+
+            const data = await result.json();
+            const content = data.choices?.[0]?.message?.content || '';
+            const shouldParseThinkTags =
+                options.enableThinking && isMinimaxThinkingModel(options.model);
+
+            if (shouldParseThinkTags && typeof content === 'string') {
+                const segments = parseThinkTaggedContent(
+                    content,
+                    { carry: '', inThinkTag: false },
+                    true
+                );
+                let visibleContent = '';
+                let thinkingContent = '';
+
+                for (const segment of segments) {
+                    if (segment.type === 'thinking') {
+                        thinkingContent += segment.text;
+                    } else {
+                        visibleContent += segment.text;
+                    }
+                }
+
+                if (thinkingContent) {
+                    options.onThinkingChunk?.(thinkingContent);
+                    options.onThinkingComplete?.(thinkingContent);
+                }
+
+                if (visibleContent) {
+                    options.onChunk?.(visibleContent);
+                }
+
+                options.onComplete?.(visibleContent);
+            } else {
+                options.onChunk?.(content);
+                options.onComplete?.(content);
+            }
+        } catch (error) {
+            console.error('Chat error:', error);
+            options.onError?.(error as Error);
+            throw error;
+        }
+        return;
+    }
+
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -1089,7 +1183,9 @@ async function chatGeminiFormat(
     model: string,
     options: ChatOptions
 ): Promise<void> {
-    const url = `${baseUrl}/v1beta/models/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
+    const streamUrl = `${baseUrl}/v1beta/models/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
+    const nonStreamUrl = `${baseUrl}/v1beta/models/${model}:generateContent?key=${apiKey}`;
+    const url = options.useForwardProxy ? nonStreamUrl : streamUrl;
 
     // 转换消息格式
     const contents = await prepareGeminiContents(options.messages);
@@ -1151,6 +1247,101 @@ async function chatGeminiFormat(
         requestBody.systemInstruction = {
             parts: [{ text: systemInstruction.content }]
         };
+    }
+
+    // ===== forwardProxy 模式：通过思源后端绕过 CORS =====
+    if (options.useForwardProxy) {
+        try {
+            const result = await forwardProxyFetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(requestBody),
+                timeout: 120000
+            });
+
+            if (!result.ok) {
+                let errorMessage = `Gemini API request failed: ${result.status}`;
+                try {
+                    const errorData = await result.json();
+                    const detailMsg = errorData.error?.message || errorData.message || errorData.error || JSON.stringify(errorData);
+                    errorMessage += `\n\n${detailMsg}`;
+                } catch (e) {
+                    try {
+                        const errorText = await result.text();
+                        if (errorText) errorMessage += `\n\n${errorText}`;
+                    } catch (_) {}
+                }
+                throw new Error(errorMessage);
+            }
+
+            const data = await result.json();
+            let fullText = '';
+            let thinkingText = '';
+            let isThinkingPhase = false;
+            const toolCalls: ToolCall[] = [];
+            const generatedImages: GeneratedImageData[] = [];
+
+            if (data.candidates?.[0]?.content?.parts) {
+                for (const part of data.candidates[0].content.parts) {
+                    const inlineData = part.inline_data || part.inlineData;
+                    if (inlineData) {
+                        generatedImages.push({
+                            mimeType: inlineData.mime_type || inlineData.mimeType || 'image/png',
+                            data: inlineData.data
+                        });
+                        continue;
+                    }
+
+                    if (!part.text) continue;
+
+                    if (options.enableThinking && part.thought === true) {
+                        isThinkingPhase = true;
+                        thinkingText += part.text;
+                        options.onThinkingChunk?.(part.text);
+                    } else {
+                        if (isThinkingPhase && options.onThinkingComplete) {
+                            options.onThinkingComplete(thinkingText);
+                            isThinkingPhase = false;
+                        }
+                        fullText += part.text;
+                        options.onChunk?.(part.text);
+                    }
+
+                    if (part.functionCall) {
+                        toolCalls.push({
+                            id: `call_${Math.random().toString(36).substring(2, 9)}`,
+                            type: 'function',
+                            function: {
+                                name: part.functionCall.name,
+                                arguments: typeof part.functionCall.args === 'string'
+                                    ? part.functionCall.args
+                                    : JSON.stringify(part.functionCall.args || {}),
+                                thought_signature: part.functionCall.thought_signature || ''
+                            }
+                        });
+                    }
+                }
+            }
+
+            if (isThinkingPhase && options.onThinkingComplete) {
+                options.onThinkingComplete(thinkingText);
+            }
+
+            if (generatedImages.length > 0 && options.onImageGenerated) {
+                await options.onImageGenerated(generatedImages);
+            }
+
+            if (toolCalls.length > 0 && options.onToolCallComplete) {
+                options.onToolCallComplete(toolCalls);
+            }
+
+            await options.onComplete?.(fullText);
+        } catch (error) {
+            console.error('Gemini chat error:', error);
+            options.onError?.(error as Error);
+            throw error;
+        }
+        return;
     }
 
     try {
@@ -1628,6 +1819,13 @@ async function chatClaudeFormat(
             if (msg.tool_calls && msg.tool_calls.length > 0) {
                 const content: any[] = [];
                 
+                // Claude API 要求：若历史消息包含 thinking 内容，必须以 content block 格式回传，
+                // 否则模型在继续对话时可能丢失上下文或行为异常。
+                // OpenAI 格式使用 reasoning_content 字段回传，Claude 格式则使用 {type: 'thinking'} block。
+                if (msg.thinking) {
+                    content.push({ type: 'thinking', thinking: msg.thinking });
+                }
+                
                 // 添加文本内容（如果有）
                 if (msg.content) {
                     content.push({ type: 'text', text: msg.content });
@@ -1745,6 +1943,93 @@ async function chatClaudeFormat(
         'anthropic-version': '2023-06-01'
     };
 
+    // ===== forwardProxy 模式：强制非流式，通过思源后端绕过 CORS =====
+    // Claude 的流式响应使用 SSE 格式，但思源 forwardProxy 不支持 streaming，
+    // 因此强制 stream: false，复用非流式响应处理逻辑。
+    if (options.useForwardProxy) {
+        requestBody.stream = false;
+
+        try {
+            const result = await forwardProxyFetch(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(requestBody),
+                timeout: 120000
+            });
+
+            // 错误处理：优先提取 JSON 中的 error.message，降级为纯文本
+            if (!result.ok) {
+                let errorMessage = `Claude API request failed: ${result.status}`;
+                try {
+                    const errorData = await result.json();
+                    const detailMsg = errorData.error?.message || errorData.message || JSON.stringify(errorData);
+                    errorMessage += `\n\n${detailMsg}`;
+                } catch (e) {
+                    try {
+                        const errorText = await result.text();
+                        if (errorText) errorMessage += `\n\n${errorText}`;
+                    } catch (_) {}
+                }
+                throw new Error(errorMessage);
+            }
+
+            const data = await result.json();
+            let content = '';
+            let thinking = '';
+            const toolCalls: ToolCall[] = [];
+
+            // Claude 非流式响应格式：data.content 是 block 数组，
+            // 每个 block 有 type 字段（thinking / text / tool_use），
+            // 与 OpenAI 的 choices[0].message.content 格式完全不同，需要遍历解析。
+            if (data.content && Array.isArray(data.content)) {
+                for (const block of data.content) {
+                    if (block.type === 'thinking' && block.thinking) {
+                        thinking += block.thinking;
+                    } else if (block.type === 'text' && block.text) {
+                        content += block.text;
+                    } else if (block.type === 'tool_use') {
+                        // 将 Claude 的 tool_use block 转换为插件内部的 ToolCall 格式
+                        toolCalls.push({
+                            id: block.id,
+                            type: 'function',
+                            function: {
+                                name: block.name,
+                                arguments: JSON.stringify(block.input || {})
+                            }
+                        });
+                    }
+                }
+            }
+
+            // 触发回调：按内容类型分别通知前端
+            // thinking 内容 → onThinkingComplete（一次性显示思考过程）
+            if (thinking) {
+                options.onThinkingComplete?.(thinking);
+            }
+
+            // 文本内容 → onChunk（显示到聊天界面）
+            if (content) {
+                options.onChunk?.(content);
+            }
+
+            // 工具调用 → onToolCall / onToolCallComplete（Agent 模式）
+            for (const toolCall of toolCalls) {
+                options.onToolCall?.(toolCall);
+            }
+            if (toolCalls.length > 0 && options.onToolCallComplete) {
+                options.onToolCallComplete(toolCalls);
+            }
+
+            // 完成回调：通知前端本轮对话结束
+            options.onComplete?.(content);
+        } catch (error) {
+            console.error('Claude chat error:', error);
+            options.onError?.(error as Error);
+            throw error;
+        }
+        return;
+    }
+
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -1778,11 +2063,14 @@ async function chatClaudeFormat(
             const data = await response.json();
             // 处理 Claude 响应中的 content 数组
             let content = '';
+            let thinking = '';
             const toolCalls: ToolCall[] = [];
             
             if (data.content && Array.isArray(data.content)) {
                 for (const block of data.content) {
-                    if (block.type === 'text' && block.text) {
+                    if (block.type === 'thinking' && block.thinking) {
+                        thinking += block.thinking;
+                    } else if (block.type === 'text' && block.text) {
                         content += block.text;
                     } else if (block.type === 'tool_use') {
                         // 处理 tool_use
@@ -1796,6 +2084,11 @@ async function chatClaudeFormat(
                         });
                     }
                 }
+            }
+            
+            // 发送 thinking 内容
+            if (thinking) {
+                options.onThinkingComplete?.(thinking);
             }
             
             // 发送文本内容
@@ -2145,7 +2438,8 @@ export interface ImageGenerationResult {
 export async function generateImage(
     provider: string,
     options: ImageGenerationOptions,
-    customApiUrl?: string
+    customApiUrl?: string,
+    useForwardProxy?: boolean
 ): Promise<ImageGenerationResult> {
     const isBuiltIn = ['gemini', 'deepseek', 'openai', 'moonshot', 'volcano', 'Achuan', 'minimax'].includes(provider);
     const config = isBuiltIn ? PROVIDER_CONFIGS[provider as AIProvider] : PROVIDER_CONFIGS.custom;
@@ -2225,12 +2519,26 @@ export async function generateImage(
     }
 
     try {
-        const response = await fetch(url, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify(requestBody),
-            signal: options.signal
-        });
+        let response: Response;
+        if (useForwardProxy) {
+            const result = await forwardProxyFetch(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(requestBody),
+                timeout: 120000
+            });
+            response = new Response(await result.text(), {
+                status: result.status,
+                headers: result.headers
+            });
+        } else {
+            response = await fetch(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(requestBody),
+                signal: options.signal
+            });
+        }
 
         if (!response.ok) {
             let errorMessage = `Image generation failed: ${response.status} ${response.statusText}`;

--- a/src/ai-sidebar.svelte
+++ b/src/ai-sidebar.svelte
@@ -867,6 +867,7 @@
                     response.provider,
                     {
                         apiKey: providerConfig.apiKey,
+                        useForwardProxy: providerConfig.useForwardProxy || false,
                         model: modelConfig.id,
                         messages: modelMessagesToSend,
                         temperature: tempModelSettings.temperatureEnabled
@@ -1153,6 +1154,7 @@
                 response.provider,
                 {
                     apiKey: providerConfig.apiKey,
+                    useForwardProxy: providerConfig.useForwardProxy || false,
                     model: modelConfig.id,
                     messages: messagesToSend,
                     temperature: tempModelSettings.temperatureEnabled
@@ -3234,6 +3236,7 @@
                         model.provider,
                         {
                             apiKey: providerConfig.apiKey,
+                            useForwardProxy: providerConfig.useForwardProxy || false,
                             model: modelConfig.id,
                             messages: modelMessagesToSend,
                             temperature: tempModelSettings.temperatureEnabled
@@ -4178,6 +4181,7 @@
                 settings.autoRenameProvider,
                 {
                     apiKey: providerConfig.apiKey,
+                    useForwardProxy: providerConfig.useForwardProxy || false,
                     model: modelConfig.id,
                     messages: [{ role: 'user', content: prompt }],
                     temperature: modelConfig.temperature,
@@ -5718,6 +5722,7 @@
                         currentProvider,
                         {
                             apiKey: providerConfig.apiKey,
+                            useForwardProxy: providerConfig.useForwardProxy || false,
                             model: modelConfig.id,
                             messages: messagesToSend,
                             temperature: tempModelSettings.temperatureEnabled
@@ -6152,6 +6157,7 @@
                     currentProvider,
                     {
                         apiKey: providerConfig.apiKey,
+                        useForwardProxy: providerConfig.useForwardProxy || false,
                         model: modelConfig.id,
                         messages: messagesToSend,
                         temperature: tempModelSettings.temperatureEnabled
@@ -11095,6 +11101,7 @@
                         currentProvider,
                         {
                             apiKey: providerConfig.apiKey,
+                            useForwardProxy: providerConfig.useForwardProxy || false,
                             model: modelConfig.id,
                             messages: messagesToSend,
                             temperature: tempModelSettings.temperatureEnabled
@@ -11544,6 +11551,7 @@
                     currentProvider,
                     {
                         apiKey: providerConfig.apiKey,
+                        useForwardProxy: providerConfig.useForwardProxy || false,
                         model: modelConfig.id,
                         messages: messagesToSend,
                         temperature: tempModelSettings.temperatureEnabled

--- a/src/api.ts
+++ b/src/api.ts
@@ -662,6 +662,54 @@ export async function forwardProxy(
     return request(url1, data);
 }
 
+/**
+ * 将 forwardProxy 包装为类 fetch 接口，用于替代浏览器原生 fetch 绕过 CORS
+ *
+ * 限制：
+ * - 不支持 streaming（因 body 为完整字符串）
+ * - 不支持 AbortSignal
+ * - 默认超时 120 秒（覆盖原 7000ms）
+ */
+export async function forwardProxyFetch(
+    url: string,
+    init?: {
+        method?: string;
+        headers?: Record<string, string>;
+        body?: string;
+        timeout?: number;
+    }
+): Promise<{
+    ok: boolean;
+    status: number;
+    headers: Headers;
+    json: () => Promise<any>;
+    text: () => Promise<string>;
+}> {
+    const method = init?.method || 'GET';
+    const headersArray = Object.entries(init?.headers || {}).map(([name, value]) => ({
+        [name]: value
+    }));
+    const result = await forwardProxy(
+        url,
+        method,
+        init?.body || '',
+        headersArray,
+        init?.timeout || 120000,
+        'application/json'
+    );
+    const responseHeaders = new Headers();
+    Object.entries(result.headers || {}).forEach(([key, value]) => {
+        responseHeaders.set(key, value);
+    });
+    return {
+        ok: result.status >= 200 && result.status < 300,
+        status: result.status,
+        headers: responseHeaders,
+        json: async () => JSON.parse(result.body),
+        text: async () => result.body,
+    };
+}
+
 
 // **************************************** AttributeView (Database) ****************************************
 

--- a/src/components/ProviderConfigPanel.svelte
+++ b/src/components/ProviderConfigPanel.svelte
@@ -225,7 +225,9 @@
                 providerId,
                 config.apiKey,
                 config.customApiUrl,
-                config.advancedConfig
+                config.advancedConfig,
+                config.useForwardProxy,
+                config.advancedConfig?.chatInterface
             );
             // 去重：使用 Map 以模型 ID 为键进行去重
             const uniqueModelsMap = new Map();
@@ -560,6 +562,24 @@
                         <use xlink:href={showApiKey ? '#iconEye' : '#iconEyeoff'}></use>
                     </svg>
                 </button>
+            </div>
+        </div>
+
+        <div>
+            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                <input
+                    type="checkbox"
+                    class="b3-switch"
+                    checked={config.useForwardProxy || false}
+                    on:change={e => {
+                        config.useForwardProxy = e.currentTarget.checked;
+                        dispatch('change');
+                    }}
+                />
+                <span>{i18n('platform.useForwardProxy')}</span>
+            </label>
+            <div class="b3-label__text label-description">
+                {i18n('platform.useForwardProxyHint')}
             </div>
         </div>
 

--- a/src/components/TranslateDialog.svelte
+++ b/src/components/TranslateDialog.svelte
@@ -334,6 +334,7 @@ Translate the above text enclosed with <translate_input> into {outputLanguage} w
 
             await chat(translateProvider, {
                 apiKey: providerConfig.apiKey,
+                useForwardProxy: providerConfig.useForwardProxy || false,
                 model: modelConfig.id,
                 messages: translateMessages,
                 temperature: temperature,

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -26,6 +26,7 @@ export interface ProviderConfig {
     models: ModelConfig[];
     enabled?: boolean; // 平台是否启用
     customWebsiteUrl?: string; // 自定义官网链接
+    useForwardProxy?: boolean; // 是否使用思源笔记后端代理绕过 CORS
     advancedConfig?: {
         customModelsUrl?: string; // 自定义模型列表 URL
         customChatUrl?: string;   // 自定义对话 URL


### PR DESCRIPTION
## 问题背景

在浏览器环境中直接调用 Kimi Code API  Anthropic 兼容接口时，会遇到 CORS 跨域限制。思源笔记提供了 `forwardProxy` 后端 API，可以代为发送 HTTP 请求从而绕过此限制。同时考虑到可能其他 API 也会有这种问题，因此开发了一个思源代理功能。

## 本次改动

- 新增 `forwardProxyFetch()` 包装函数，将 `fetch` 风格的对象 headers 转换为思源后端要求的数组格式
- `chatOpenAIFormat` / `chatClaudeFormat` / `chatGeminiFormat` 均支持通过 `useForwardProxy` 走代理模式
- 启用代理后强制非流式（`stream: false`），复用现有非流式响应处理逻辑
- `fetchModels` 添加 `chatInterface` 参数，修复 Anthropic 接口使用 `x-api-key` 认证
- `generateImage` 同步支持代理模式
- UI 添加 per-provider `useForwardProxy` 开关
- 同步 i18n 中英翻译

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/api.ts` | 新增 `forwardProxyFetch` 函数 |
| `src/ai-chat.ts` | 三格式聊天函数代理分支 + `fetchModels` 认证修复 |
| `src/ai-sidebar.svelte` | 传递 `useForwardProxy` |
| `src/components/ProviderConfigPanel.svelte` | 添加代理开关 UI |
| `src/components/TranslateDialog.svelte` | 传递 `useForwardProxy` |
| `src/defaultSettings.ts` | `ProviderConfig` 添加 `useForwardProxy` 字段 |
| `i18n/zh_CN.json` / `en_US.json` | 添加 `useForwardProxy` / `useForwardProxyHint` |