### PR TITLE
修复 OpenAI 兼容接口的非流式工具调用

### DIFF
--- a/src/ai-chat.ts
+++ b/src/ai-chat.ts
@@ -475,6 +475,22 @@ function hasAssistantToolCalls(message: any): boolean {
     return message?.role === 'assistant' && Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
 }
 
+async function handleNonStreamingOpenAIToolCalls(data: any, options: ChatOptions): Promise<boolean> {
+    const message = data?.choices?.[0]?.message;
+    const toolCalls = message?.tool_calls;
+
+    if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+        return false;
+    }
+
+    if (!options.onToolCallComplete) {
+        return false;
+    }
+
+    await options.onToolCallComplete(toolCalls);
+    return true;
+}
+
 function hasSendableAssistantContent(message: any): boolean {
     if (!message || message.role !== 'assistant') return true;
 
@@ -1118,6 +1134,10 @@ async function chatOpenAIFormat(
             }
 
             const data = await result.json();
+            if (await handleNonStreamingOpenAIToolCalls(data, options)) {
+                return;
+            }
+
             const content = data.choices?.[0]?.message?.content || '';
             const shouldParseThinkTags =
                 options.enableThinking && isMinimaxThinkingModel(options.model);
@@ -1195,6 +1215,10 @@ async function chatOpenAIFormat(
             await handleStreamResponse(response.body, options);
         } else {
             const data = await response.json();
+            if (await handleNonStreamingOpenAIToolCalls(data, options)) {
+                return;
+            }
+
             const content = data.choices?.[0]?.message?.content || '';
             const shouldParseThinkTags =
                 options.enableThinking && isMinimaxThinkingModel(options.model);


### PR DESCRIPTION
## 摘要

修复 OpenAI 兼容接口在非流式响应中返回 `message.tool_calls` 时，插件没有继续执行工具的问题。

当开启 `useForwardProxy` 时，插件会把 OpenAI 兼容请求强制改为 `stream: false`。一些 OpenAI 兼容中转站会按标准把工具调用返回在 `choices[0].message.tool_calls` 中，同时 `message.content` 为空。原来的非流式分支只读取 `message.content`，没有处理 `tool_calls`，因此 Agent 模式会出现空白回复，并且不会进入后续工具执行流程。

## 修改内容

- 为 OpenAI 兼容的非流式响应补充 `choices[0].message.tool_calls` 处理。
- 存在工具调用时复用现有 `onToolCallComplete` 回调，让 Agent 模式继续走原有工具执行流程。
- 同时覆盖普通非流式请求和思源代理 `useForwardProxy` 路径。
- 如果当前调用没有注册工具回调，则保留原来的文本完成逻辑，避免影响普通对话。

## 验证

- 已运行 `npm run build`，构建成功。
- 构建过程中仍有项目既有的 Svelte a11y / unused CSS 警告，以及 Sass legacy API deprecation 警告，但没有构建失败。